### PR TITLE
Fix App building bug.

### DIFF
--- a/orange/Orange.cs
+++ b/orange/Orange.cs
@@ -14,7 +14,7 @@ Commands:
     - sync
     - build
     - add (library path) ";
-        static readonly string _version = "v1.0.1";
+        static readonly string _version = "v1.0.2";
         static readonly string _help = V;
         static void Main(string[] args)
         {
@@ -119,11 +119,6 @@ Commands:
                 Information info = libraryinfo.LoadCfg("app.cfg");
                 CollinExecute.Shell.SystemCommand("make clean");
                 Directory.CreateDirectory("build");
-                if (!File.Exists("library.cfg"))
-                {
-                    Console.Error.WriteLine("Error: Source file 'library.cfg' does not exist.");
-                    return;
-                }
                 File.Copy("app.cfg", "build/app.cfg");
                 bool success = CollinExecute.Shell.SystemCommand("make");
                 if (!success)


### PR DESCRIPTION
This pull request includes updates to the `orange/Orange.cs` file, focusing on versioning and build process improvements. The most important changes involve updating the version string and simplifying the build process by removing redundant checks.

### Versioning Update:
* Updated the `_version` constant from `"v1.0.1"` to `"v1.0.2"` to reflect the new version of the application. (`[orange/Orange.csL17-R17](diffhunk://#diff-6b44388d65f469899280993ac84ffeebf77af537e95078d428adcfa5245ff0f0L17-R17)`)

### Build Process Improvements:
* Removed the check for the existence of `library.cfg` and the associated error handling, streamlining the build process by assuming the required files are already in place. (`[orange/Orange.csL122-L126](diffhunk://#diff-6b44388d65f469899280993ac84ffeebf77af537e95078d428adcfa5245ff0f0L122-L126)`)