### PR TITLE
Add feature: streaming

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,32 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.x.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -483,7 +483,7 @@ Author: Test Author
         {
             // Test with nonexistent zip file
             // This should not throw an exception but handle it gracefully
-            library.InstallLibrary("nonexistent.zip");
+            Library.InstallLibrary("nonexistent.zip");
             // If we get here, the method handled the error gracefully
             Assert.True(true);
         }
@@ -515,7 +515,7 @@ Author: Test Author
                     ReadmeContents = "Test README"
                 };
                 
-                library.CreateLibrary(libraryInfo);
+                Library.CreateLibrary(libraryInfo);
                 
                 // Verify library.zip was created
                 Assert.True(File.Exists("library.zip"));

--- a/orange/Orange.cs
+++ b/orange/Orange.cs
@@ -1,6 +1,7 @@
 ﻿using OrangeLib;
 using OrangeLib.Info;
 using System.IO.Compression;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Orange
 {
@@ -13,7 +14,8 @@ Commands:
     - init (app/library)
     - sync
     - build
-    - add (library path) ";
+    - add (library path)
+    - stream (-a 3DS Ip address";
         static readonly string _version = "v1.0.2";
         static readonly string _help = V;
         static void Main(string[] args)
@@ -110,7 +112,7 @@ Commands:
             if (File.Exists("library.cfg"))
             {
                 Information info = libraryinfo.LoadCfg("library.cfg");
-                library.CreateLibrary(info);
+                Library.CreateLibrary(info);
                 Console.WriteLine("Successfully built library!");
                 return;
             }
@@ -152,6 +154,10 @@ Commands:
                 OrangeLib.Net.Internet.GetLibrary(dep).GetAwaiter().GetResult();
                 Console.WriteLine($"Installed {dep}");
             }
+        }
+        static public void Stream(string[] args)
+        {
+
         }
         private static void ShowHelp()
         {

--- a/orange/Orange.cs
+++ b/orange/Orange.cs
@@ -161,7 +161,31 @@ Commands:
         }
         static public void Stream(string[] args)
         {
-            
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: orange stream [3DS Ip address] (-r --retries Number of times to retry the connction)");
+                return;
+            }
+            string ip = args[1];
+            int retries = 1;
+            // Parse optional retries argument
+            for (int i = 2; i < args.Length - 1; i++)
+            {
+                if ((args[i] == "-r" || args[i] == "--retries") && int.TryParse(args[i + 1], out int parsedRetries))
+                {
+                    retries = parsedRetries;
+                    break;
+                }
+            }
+            bool success = OrangeLib.Streaming.Stream3dsxTo3ds(ip, retries);
+            if (success)
+            {
+                Console.WriteLine($"Successfully streamed to 3DS at {ip}.");
+            }
+            else
+            {
+                Console.WriteLine($"Failed to stream to 3DS at {ip} after {retries} attempt(s).");
+            }
         }
         private static void ShowHelp()
         {

--- a/orange/Orange.cs
+++ b/orange/Orange.cs
@@ -11,11 +11,11 @@ namespace Orange
     {
         private const string V = @"Usage: orange [command] [options]
 Commands:
-    - init (app/library)
+    - init [app/library]
     - sync
     - build
-    - add (library path)
-    - stream (-a 3DS Ip address";
+    - add [library name]
+    - stream [3DS Ip address] (-r --retries Number of times to retry the connction)";
         static readonly string _version = "v1.0.2";
         static readonly string _help = V;
         static void Main(string[] args)
@@ -35,6 +35,10 @@ Commands:
             else if (args[0] == "upload")
             {
                 Console.WriteLine("Ha! you found a removed command. go to the github to upload a library...");
+            }
+            else if (args[0] == "stream")
+            {
+                Stream(args);
             }
             else if (args[0] == "init")
             {
@@ -157,7 +161,7 @@ Commands:
         }
         static public void Stream(string[] args)
         {
-
+            
         }
         private static void ShowHelp()
         {

--- a/orangelib/Internet.cs
+++ b/orangelib/Internet.cs
@@ -54,7 +54,7 @@ namespace OrangeLib.Net
                     await Console.Error.WriteLineAsync($"Downloaded file is not a valid ZIP archive: {tempFilePath}").ConfigureAwait(false);
                     return;
                 }
-                library.InstallLibrary(tempFilePath);
+                Library.InstallLibrary(tempFilePath);
             }
             catch (Exception ex)
             {

--- a/orangelib/OrangeLib.cs
+++ b/orangelib/OrangeLib.cs
@@ -7,7 +7,7 @@ namespace OrangeLib
 {
     public static class Streaming
     {
-        static bool Stream3dsxTo3ds(string ip, int retrys)
+        public static bool Stream3dsxTo3ds(string ip, int retrys)
         {
             int i = 0;
             while (i > retrys)

--- a/orangelib/OrangeLib.cs
+++ b/orangelib/OrangeLib.cs
@@ -5,12 +5,30 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 namespace OrangeLib
 {
+    public static class Streaming
+    {
+        static bool Stream3dsxTo3ds(string ip, int retrys)
+        {
+            int i = 0;
+            while (i > retrys)
+            {
+                try
+                {
+                    bool success = CollinExecute.Shell.SystemCommand($"3dslink -a {ip} -r {retrys}", false, true);
+                }
+                catch { 
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
     public static class Utils
     {
         public static bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         public static bool IsMacOS() => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsLinux() => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-// Only for specific use.
+        // Only for specific use.
         public static bool ExecuteShellCommand(string command)
         {
             try
@@ -26,7 +44,7 @@ namespace OrangeLib
                     process.StartInfo.FileName = "/bin/bash";
                     process.StartInfo.Arguments = $"-c \"{command}\"";
                 }
-                
+
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.CreateNoWindow = true;
                 process.Start();
@@ -101,7 +119,7 @@ namespace OrangeLib
             }
         }
     }
-    static public class library
+    static public class Library
     {
         public static void CreateLibrary(Information libraryinfo)
         {


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and testing a .NET project, refactors code to improve consistency in naming conventions, and adds a new streaming feature to the `orange` CLI tool. Below are the key changes grouped by theme:

### CI/CD Enhancements:
* Added a `.NET` GitHub Actions workflow (`.github/workflows/dotnet.yml`) to automate building, restoring dependencies, and testing for `.NET` projects on `main` and `dev` branches.

### Code Refactoring:
* Renamed the `library` class to `Library` across multiple files for consistency in naming conventions. This change affects methods like `InstallLibrary` and `CreateLibrary` in `Tests.cs`, `Orange.cs`, `Internet.cs`, and `OrangeLib.cs`. [[1]](diffhunk://#diff-ff54291116b97a85f8a28d1a98d848d633848a3d0e8e31610ce12177764e9893L486-R486) [[2]](diffhunk://#diff-ff54291116b97a85f8a28d1a98d848d633848a3d0e8e31610ce12177764e9893L518-R518) [[3]](diffhunk://#diff-6b44388d65f469899280993ac84ffeebf77af537e95078d428adcfa5245ff0f0L113-R119) [[4]](diffhunk://#diff-2f5234b85e0258608de1aa6ec281f01cb06a2fd91c9ecc885b8208d9012a4516L57-R57) [[5]](diffhunk://#diff-4a6aea453c27b40c1cd1780d72bdc04e43f4e3348fca784fb6d35accd3c03e1bL104-R122)

### New Feature: Streaming Support:
* Added a new `stream` command to the `orange` CLI tool, allowing users to stream `.3dsx` files to a 3DS device over the network. The command includes an optional `-r` or `--retries` flag to specify the number of retry attempts. [[1]](diffhunk://#diff-6b44388d65f469899280993ac84ffeebf77af537e95078d428adcfa5245ff0f0L13-R18) [[2]](diffhunk://#diff-6b44388d65f469899280993ac84ffeebf77af537e95078d428adcfa5245ff0f0R39-R42) [[3]](diffhunk://#diff-6b44388d65f469899280993ac84ffeebf77af537e95078d428adcfa5245ff0f0R162-R189)
* Implemented the `Streaming.Stream3dsxTo3ds` method in `OrangeLib.cs` to handle the streaming logic, including retry functionality.

### Minor Updates:
* Updated the `using` directives in `Orange.cs` to include `System.Security.Cryptography.X509Certificates`, though its purpose in this context is unclear.

These changes enhance the project by introducing automation, improving code maintainability, and adding a new feature for end users.